### PR TITLE
Fix so building assembly files under VS2013 (and 2012 and 2015) don't…

### DIFF
--- a/vpx/msvc/vs2012/libvpx.vcxproj
+++ b/vpx/msvc/vs2012/libvpx.vcxproj
@@ -67,14 +67,12 @@
   <ItemDefinitionGroup>
     <CustomBuild>
       <Message>Assembling %(Filename)%(Extension)</Message>
-	  <TargetFileName>$(IntDir)%(Filename)_asm.obj</TargetFileName>
+	  <TargetFileName>$(IntDir)asm\%(FileName).obj</TargetFileName>
       <Outputs>%(TargetFileName)</Outputs>
-      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
-      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vpx/msvc/vs2013/libvpx.vcxproj
+++ b/vpx/msvc/vs2013/libvpx.vcxproj
@@ -67,14 +67,12 @@
   <ItemDefinitionGroup>
     <CustomBuild>
       <Message>Assembling %(Filename)%(Extension)</Message>
-	  <TargetFileName>$(IntDir)%(Filename)_asm.obj</TargetFileName>
+	  <TargetFileName>$(IntDir)asm\%(FileName).obj</TargetFileName>
       <Outputs>%(TargetFileName)</Outputs>
-      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
-      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vpx/msvc/vs2015/libvpx.vcxproj
+++ b/vpx/msvc/vs2015/libvpx.vcxproj
@@ -67,14 +67,12 @@
   <ItemDefinitionGroup>
     <CustomBuild>
       <Message>Assembling %(Filename)%(Extension)</Message>
-	  <TargetFileName>$(IntDir)%(Filename)_asm.obj</TargetFileName>
+	  <TargetFileName>$(IntDir)asm\%(FileName).obj</TargetFileName>
       <Outputs>%(TargetFileName)</Outputs>
-      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
-      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)%(Filename)_asm.obj" del "$(IntDir)%(Filename)_asm.obj" /q
-vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)%(Filename)_asm.obj" "%(FullPath)"
-IF EXIST "$(IntDir)%(Filename).obj" ren "$(IntDir)%(Filename).obj" "%(Filename)_asm.obj"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'!='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -g cv8 -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(WholeProgramOptimization)'=='true'">IF EXIST "$(IntDir)asm\%(Filename).obj" del "$(IntDir)asm\%(Filename).obj" /q
+vsyasm -Xvc -f win32 -I"../.." -o "$(IntDir)asm\%(Filename).obj" "%(FullPath)"</Command>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
… change output name which caused linker to get NAME_asm_asm.obj to link to sometimes.

With the current process for handling the assembler output, there is a race condition on the creation of the output (it depends if the .c or .asm file is built first).  By moving the assembly files into a subdirectory, it avoids the problem of the name collisions that currently exist.  It also fixes a bug where the link could end up with a file not found trying to link to %(filename)_asm.obj and getting a name like %(originalfilename)_asm_asm.obj
