### PR TITLE
User should have possibility to update each individual clip manually

### DIFF
--- a/theoraplayer/include/theoraplayer/VideoClip.h
+++ b/theoraplayer/include/theoraplayer/VideoClip.h
@@ -145,6 +145,8 @@ namespace theoraplayer
 		bool isDone() const;
 		bool isPaused() const;
 
+		/// @bried Advance times. Manager calls this.
+		void update(float timeDelta);
 		/// @brief Update timer to the display time of the next frame. This is useful if you want to grab frames instead of regular display.
 		/// @return The time advanced. 0 if no frames are ready.
 		/// @note On an abstract level, this works similar to seek, but on a practical level it's different.
@@ -229,9 +231,6 @@ namespace theoraplayer
 
 		bool _isBusy() const;
 		float _getAbsPlaybackTime() const;
-
-		/// @bried Advance times. Manager calls this.
-		void _update(float timeDelta);
 
 		virtual void _load(DataSource* source) = 0;
 		virtual bool _readData() = 0;

--- a/theoraplayer/src/Manager.cpp
+++ b/theoraplayer/src/Manager.cpp
@@ -272,7 +272,7 @@ namespace theoraplayer
 		Mutex::ScopeLock lock(this->workMutex);
 		foreach (VideoClip*, it, this->clips)
 		{
-			(*it)->_update(timeDelta);
+			(*it)->update(timeDelta);
 			(*it)->_decodedAudioCheck();
 		}
 		lock.release();

--- a/theoraplayer/src/VideoClip.cpp
+++ b/theoraplayer/src/VideoClip.cpp
@@ -242,7 +242,7 @@ namespace theoraplayer
 		{
 			return 0.0f;
 		}
-		this->_update(time);
+		this->update(time);
 		return time;
 	}
 
@@ -371,7 +371,7 @@ namespace theoraplayer
 		return ((float)readyCount / frameQueueSize);
 	}
 
-	void VideoClip::_update(float timeDelta)
+	void VideoClip::update(float timeDelta)
 	{
 		if (this->timer->isPaused())
 		{


### PR DESCRIPTION
VideoClip::_update() function made public and renamed to VideoClip::update(). User should have possibility to update each individual clip manually instead of always be forced to use Manager::update() for all clips at once.
VideoClip::update() is used to be in public section until commit 49bf03bc06482e54f1e8ac240bdfa3731f561cbc. 