### PR TITLE
Xcopy arguments quoted

### DIFF
--- a/msvc/vs2012/props-demos/configuration.props
+++ b/msvc/vs2012/props-demos/configuration.props
@@ -17,9 +17,9 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy $(OutDir)..\..\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\glut\lib\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\OpenAL\lib\*.dll $(OutDir) /d /y</Command>
+      <Command>xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\glut\lib\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\OpenAL\lib\*.dll" "$(OutDir)" /d /y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 </Project>

--- a/msvc/vs2013/props-demos/configuration.props
+++ b/msvc/vs2013/props-demos/configuration.props
@@ -17,9 +17,9 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy $(OutDir)..\..\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\glut\lib\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\OpenAL\lib\*.dll $(OutDir) /d /y</Command>
+      <Command>xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\glut\lib\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\OpenAL\lib\*.dll" "$(OutDir)" /d /y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 </Project>

--- a/msvc/vs2015/props-demos/configuration.props
+++ b/msvc/vs2015/props-demos/configuration.props
@@ -17,9 +17,9 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy $(OutDir)..\..\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\glut\lib\*.dll $(OutDir) /d /y
-xcopy ..\..\demos\dependencies\win32\OpenAL\lib\*.dll $(OutDir) /d /y</Command>
+      <Command>xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\glut\lib\*.dll" "$(OutDir)" /d /y
+xcopy "..\..\demos\dependencies\win32\OpenAL\lib\*.dll" "$(OutDir)" /d /y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
 </Project>

--- a/theoraplayer/include/theoraplayer/VideoClip.h
+++ b/theoraplayer/include/theoraplayer/VideoClip.h
@@ -145,6 +145,8 @@ namespace theoraplayer
 		bool isDone() const;
 		bool isPaused() const;
 
+		/// @bried Advance times. Manager calls this.
+		void update(float timeDelta);
 		/// @brief Update timer to the display time of the next frame. This is useful if you want to grab frames instead of regular display.
 		/// @return The time advanced. 0 if no frames are ready.
 		/// @note On an abstract level, this works similar to seek, but on a practical level it's different.
@@ -229,9 +231,6 @@ namespace theoraplayer
 
 		bool _isBusy() const;
 		float _getAbsPlaybackTime() const;
-
-		/// @bried Advance times. Manager calls this.
-		void _update(float timeDelta);
 
 		virtual void _load(DataSource* source) = 0;
 		virtual bool _readData() = 0;

--- a/theoraplayer/msvc/vs2012/props-generic/build-defaults.props
+++ b/theoraplayer/msvc/vs2012/props-generic/build-defaults.props
@@ -17,10 +17,10 @@
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <PostBuildEvent>
-      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V
-xcopy $(OutDir)$(TargetName).lib $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy $(OutDir)..\..\*.dll $(OutDir) /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V
+xcopy "$(OutDir)$(TargetName).lib" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /Y /V</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WholeProgramOptimization)'!='true'">

--- a/theoraplayer/msvc/vs2013-winp8/props-generic/build-defaults.props
+++ b/theoraplayer/msvc/vs2013-winp8/props-generic/build-defaults.props
@@ -25,10 +25,10 @@
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <PostBuildEvent>
-      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V
-xcopy $(OutDir)$(TargetName).lib $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy $(OutDir)..\..\*.dll $(OutDir) /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V
+xcopy "$(OutDir)$(TargetName).lib" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /Y /V</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WholeProgramOptimization)'!='true'">

--- a/theoraplayer/msvc/vs2013-winrt/props-generic/build-defaults.props
+++ b/theoraplayer/msvc/vs2013-winrt/props-generic/build-defaults.props
@@ -25,10 +25,10 @@
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <PostBuildEvent>
-      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V
-xcopy $(OutDir)$(TargetName).lib $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy $(OutDir)..\..\*.dll $(OutDir) /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V
+xcopy "$(OutDir)$(TargetName).lib" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /Y /V</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WholeProgramOptimization)'!='true'">

--- a/theoraplayer/msvc/vs2013/props-generic/build-defaults.props
+++ b/theoraplayer/msvc/vs2013/props-generic/build-defaults.props
@@ -17,10 +17,10 @@
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <PostBuildEvent>
-      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V
-xcopy $(OutDir)$(TargetName).lib $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy $(OutDir)..\..\*.dll $(OutDir) /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V
+xcopy "$(OutDir)$(TargetName).lib" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /Y /V</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WholeProgramOptimization)'!='true'">

--- a/theoraplayer/msvc/vs2015/props-generic/build-defaults.props
+++ b/theoraplayer/msvc/vs2015/props-generic/build-defaults.props
@@ -17,10 +17,10 @@
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <PostBuildEvent>
-      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy $(TargetPath) $(OutDir)..\..\..\ /Y /V
-xcopy $(OutDir)$(TargetName).lib $(OutDir)..\..\..\ /Y /V</Command>
-      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy $(OutDir)..\..\*.dll $(OutDir) /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='StaticLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='DynamicLibrary'">xcopy "$(TargetPath)" "$(OutDir)..\..\..\" /Y /V
+xcopy "$(OutDir)$(TargetName).lib" "$(OutDir)..\..\..\" /Y /V</Command>
+      <Command Condition="'$(ConfigurationType)'=='Application'">xcopy "$(OutDir)..\..\*.dll" "$(OutDir)" /Y /V</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WholeProgramOptimization)'!='true'">

--- a/theoraplayer/src/Manager.cpp
+++ b/theoraplayer/src/Manager.cpp
@@ -272,7 +272,7 @@ namespace theoraplayer
 		Mutex::ScopeLock lock(this->workMutex);
 		foreach (VideoClip*, it, this->clips)
 		{
-			(*it)->_update(timeDelta);
+			(*it)->update(timeDelta);
 			(*it)->_decodedAudioCheck();
 		}
 		lock.release();

--- a/theoraplayer/src/VideoClip.cpp
+++ b/theoraplayer/src/VideoClip.cpp
@@ -242,7 +242,7 @@ namespace theoraplayer
 		{
 			return 0.0f;
 		}
-		this->_update(time);
+		this->update(time);
 		return time;
 	}
 
@@ -371,7 +371,7 @@ namespace theoraplayer
 		return ((float)readyCount / frameQueueSize);
 	}
 
-	void VideoClip::_update(float timeDelta)
+	void VideoClip::update(float timeDelta)
 	{
 		if (this->timer->isPaused())
 		{


### PR DESCRIPTION
Fixed: PostBuildEvent's xcopy command source and target arguments should be double quoted to allow paths with spaces.