### PR TITLE
[MemoryDataSource] Add optional 'deleteData' parameter to constructor to allow management of 'data' parameter lifespan outside of libtheoraplayer

### DIFF
--- a/theoraplayer/include/theoraplayer/MemoryDataSource.h
+++ b/theoraplayer/include/theoraplayer/MemoryDataSource.h
@@ -23,7 +23,7 @@ namespace theoraplayer
 	class theoraplayerExport MemoryDataSource : public DataSource
 	{
 	public:
-		MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename = "memory", bool deleteData=true);
+		MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename = "memory", bool deleteData = true);
 		MemoryDataSource(const std::string& filename);
 		~MemoryDataSource();
 

--- a/theoraplayer/include/theoraplayer/MemoryDataSource.h
+++ b/theoraplayer/include/theoraplayer/MemoryDataSource.h
@@ -23,7 +23,7 @@ namespace theoraplayer
 	class theoraplayerExport MemoryDataSource : public DataSource
 	{
 	public:
-		MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename = "memory");
+		MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename = "memory", bool deleteData=true);
 		MemoryDataSource(const std::string& filename);
 		~MemoryDataSource();
 
@@ -44,6 +44,7 @@ namespace theoraplayer
 		int64_t size;
 		int64_t position;
 		unsigned char* data;
+		bool deleteData;
 
 		void _loadFile();
 

--- a/theoraplayer/src/MemoryDataSource.cpp
+++ b/theoraplayer/src/MemoryDataSource.cpp
@@ -18,13 +18,14 @@
 
 namespace theoraplayer
 {
-    MemoryDataSource::MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename)
+    MemoryDataSource::MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename, bool deleteData)
 	{
 		this->filename = filename;
 		this->data = data;
 		this->size = size;
 		this->position = 0;
-        this->formatName = formatName;
+		this->formatName = formatName;
+		this->deleteData = deleteData;
 	}
 
 	MemoryDataSource::MemoryDataSource(const std::string& filename)
@@ -45,7 +46,7 @@ namespace theoraplayer
 
 	MemoryDataSource::~MemoryDataSource()
 	{
-		if (this->data != NULL)
+		if (this->deleteData && this->data != NULL)
 		{
 			delete[] this->data;
 		}

--- a/theoraplayer/src/MemoryDataSource.cpp
+++ b/theoraplayer/src/MemoryDataSource.cpp
@@ -18,7 +18,7 @@
 
 namespace theoraplayer
 {
-    MemoryDataSource::MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename, bool deleteData)
+	MemoryDataSource::MemoryDataSource(unsigned char* data, long size, const std::string& formatName, const std::string& filename, bool deleteData)
 	{
 		this->filename = filename;
 		this->data = data;
@@ -34,14 +34,14 @@ namespace theoraplayer
 		this->data = NULL;
 		this->size = 0;
 		this->position = 0;
-        VideoClip::Format format;
-        // used for determining the file format, does not throw an exception inside the ctor
-        FILE* file = openSupportedFormatFile(this->filename, format, this->fullFilename);
-        if (file != NULL)
-        {
-            fclose(file);
-        }
-        this->formatName = format.name;
+		VideoClip::Format format;
+		// used for determining the file format, does not throw an exception inside the ctor
+		FILE* file = openSupportedFormatFile(this->filename, format, this->fullFilename);
+		if (file != NULL)
+		{
+			fclose(file);
+		}
+		this->formatName = format.name;
 	}
 
 	MemoryDataSource::~MemoryDataSource()


### PR DESCRIPTION
Allow more flexibility for managing lifespan of `data` parameter outside of libtheoraplayer.

This is helpful in the following situations:
  - Variable passed as `data` needs to live longer than the MemoryDataSource created from it.
  - Variable passed as `data` was allocated using a `malloc` family function.
    - In the destructor, `data` is freed using `delete[]`, which assumes it was allocated using `new[]`. This creates a mismatch if the `data` parameter was allocated using a function from the `malloc` family.

The new `deleteData` parameter defaults to `true` so as not to have an impact on any internal theoraplayer source code. It must be explicitly set to `false` when calling the constructor.