### PR TITLE
v1.2: Fix TheoraFileDataSource::getPosition() for Linux

### DIFF
--- a/theoraplayer/src/TheoraDataSource.cpp
+++ b/theoraplayer/src/TheoraDataSource.cpp
@@ -100,7 +100,7 @@ uint64_t TheoraFileDataSource::getPosition()
 	}
 #ifdef _LINUX
 	fpos_t pos;
-	fgetpos(mFilePtr, &pos);
+	fgetpos(this->filePtr, &pos);
 	return (uint64_t) pos.__pos;
 #else
 	fpos_t pos;


### PR DESCRIPTION
Hello, I can see that your repository has not been updated for a while, so wonder if it's okay to make a PR, especially that it's for an older version.

I'm currently using the v1.2 of theoraplayer to update some very old project, as next player's version(s) have a different api. v1.2 has a small mistake that breaks compilation on Linux; it was already fixed in 2.0 branch, so I thought I'd propose same fix for 1.2 to compile properly too.

